### PR TITLE
feat: add coordinode-docs.sw.foundation bug reports endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,17 @@ const SITES: Record<string, SiteConfig> = {
       "http://localhost:4173",
     ],
   },
+  // CoordiNode docs — coordinode.com DNS is on PowerDNS (not Cloudflare),
+  // so we proxy API through this sw.foundation subdomain instead.
+  "coordinode-docs.sw.foundation": {
+    repo: "structured-world/coordinode",
+    allowedOrigins: [
+      "https://docs.coordinode.com",
+      "https://structured-world.github.io",
+      "http://localhost:5173",
+      "http://localhost:4173",
+    ],
+  },
 };
 
 const RATE_LIMIT_MAX = 5;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,10 @@ compatibility_date = "2024-12-01"
 # Routes for all documentation sites
 routes = [
   { pattern = "gitlab-mcp.sw.foundation/api/report-bug", zone_name = "sw.foundation" },
-  { pattern = "privacy.sw.foundation/api/report-bug", zone_name = "sw.foundation" }
+  { pattern = "privacy.sw.foundation/api/report-bug", zone_name = "sw.foundation" },
+  # CoordiNode docs — coordinode.com DNS is on PowerDNS (not Cloudflare),
+  # so we proxy API through this sw.foundation subdomain instead.
+  { pattern = "coordinode-docs.sw.foundation/api/report-bug", zone_name = "sw.foundation" },
 ]
 
 # KV namespace for rate limiting (shared)


### PR DESCRIPTION
## Summary
- Add `coordinode-docs.sw.foundation` to `SITES` with `repo: structured-world/coordinode`
- Add wrangler route for `/api/report-bug`

## Why a subdomain proxy?
`coordinode.com` DNS is on PowerDNS (not Cloudflare), so Cloudflare Worker zone routes for `docs.coordinode.com` are impossible. `coordinode-docs.sw.foundation` (in the `sw.foundation` CF zone) acts as API proxy — same pattern as `gitlab-mcp.sw.foundation` and `privacy.sw.foundation`.

DNS record already created: `coordinode-docs.sw.foundation CNAME structured-world.github.io (proxied)`.

Closes #34